### PR TITLE
Lock in Solidity versions make it simpler to verify contract bytecode

### DIFF
--- a/contracts/Raffle.sol
+++ b/contracts/Raffle.sol
@@ -1,6 +1,6 @@
 //SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.7;
+pragma solidity 0.8.7;
 
 import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";

--- a/contracts/RaffleFactory.sol
+++ b/contracts/RaffleFactory.sol
@@ -1,6 +1,6 @@
 //SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.7;
 
 import "./Raffle.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";


### PR DESCRIPTION
Makes it simpler to verify contract bytecode.